### PR TITLE
Passing errors via callback, accepting headers for the request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.orig
 .DS_Store
 coverage
+.nvmrc

--- a/lib/warmup.js
+++ b/lib/warmup.js
@@ -8,7 +8,7 @@ function getRandomInt (min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
-
+// Testing
 
 module.exports = function warmup(app, tasks, options, callback) {
     ok(app.listen, 'Invalid server application');
@@ -42,7 +42,7 @@ module.exports = function warmup(app, tasks, options, callback) {
         log('Warming up "' + path + '" (' + url + ')...');
 
         return function(callback) {
-            
+
             request(url, function (err, response, body) {
                 if (err) {
                     return callback(err);
@@ -80,7 +80,7 @@ module.exports = function warmup(app, tasks, options, callback) {
         });
     }
 
-    
+
 
     function doWarmup(callback) {
 
@@ -148,10 +148,9 @@ module.exports = function warmup(app, tasks, options, callback) {
             stopListening
         ], function(err) {
             if (err) {
-                stopListening();    
+                stopListening();
             }
-            
+
             callback(err);
         });
 };
-

--- a/lib/warmup.js
+++ b/lib/warmup.js
@@ -3,12 +3,9 @@ var http = require('http');
 var async = require('async');
 var request = require('request');
 
-
 function getRandomInt (min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
-
-// Testing
 
 module.exports = function warmup(app, tasks, options, callback) {
     ok(app.listen, 'Invalid server application');
@@ -34,16 +31,22 @@ module.exports = function warmup(app, tasks, options, callback) {
     var warmupPort = options.warmupPort || getRandomInt(10000, 50000);
     var listenAttemptCount = 0;
 
-    function createWarmupUrlTask(path) {
+    function createWarmupUrlTask(data) {
+        var urlObj;
+        var urlHost = 'http://localhost:' + warmupPort;
 
-
-        var url = 'http://localhost:' + warmupPort + path;
+        if (typeof data === 'object') {
+            urlObj = data;
+            urlObj.url = urlHost + data.path;
+        }
+        else {
+            urlObj = urlHost + data;
+        }
 
         log('Warming up "' + path + '" (' + url + ')...');
 
         return function(callback) {
-
-            request(url, function (err, response, body) {
+            request(urlObj, function (err, response, body) {
                 if (err) {
                     return callback(err);
                 }
@@ -80,10 +83,7 @@ module.exports = function warmup(app, tasks, options, callback) {
         });
     }
 
-
-
     function doWarmup(callback) {
-
         var context = {
             port: warmupPort
         };
@@ -123,9 +123,11 @@ module.exports = function warmup(app, tasks, options, callback) {
         }
 
         var asyncTasks = tasks.map(function(task, i) {
-            if (typeof task === 'string') {
-                return wrapTask(createWarmupUrlTask(task, warmupPort), i, task);
-            } else {
+            if (typeof task === 'string' || typeof task === 'object') {
+                console.log('\nTask: ', task);
+                return wrapTask(createWarmupUrlTask(task), i, task);
+            }
+            else {
                 return wrapTask(task, i);
             }
         });
@@ -152,5 +154,6 @@ module.exports = function warmup(app, tasks, options, callback) {
             }
 
             callback(err);
-        });
+        }
+    );
 };

--- a/lib/warmup.js
+++ b/lib/warmup.js
@@ -32,21 +32,25 @@ module.exports = function warmup(app, tasks, options, callback) {
     var listenAttemptCount = 0;
 
     function createWarmupUrlTask(data) {
-        var urlObj;
-        var urlHost = 'http://localhost:' + warmupPort;
+        var host = 'http://localost:' + warmupPort;
+        var reqObj;
+        var path;
+        var url;
 
         if (typeof data === 'object') {
-            urlObj = data;
-            urlObj.url = urlHost + data.path;
+            reqObj = data;
+            path = data.path;
+            reqObj.url = url = host + path;
         }
-        else {
-            urlObj = urlHost + data;
+        else if (typeof data === 'string') {
+            path = data;
+            reqObj = url = host + data;
         }
 
         log('Warming up "' + path + '" (' + url + ')...');
 
         return function(callback) {
-            request(urlObj, function (err, response, body) {
+            request(reqObj, function (err, response, body) {
                 if (err) {
                     return callback(err);
                 }
@@ -91,10 +95,17 @@ module.exports = function warmup(app, tasks, options, callback) {
         function wrapTask(func, i, name) {
             var logMsg = 'Running task ' + (i+1) + ' of ' + tasks.length;
             var completedLogMsg = 'Completed task ' + (i+1) + ' of ' + tasks.length;
+            var taskName;
 
             if (name) {
-                logMsg += ' (' + name + ')';
-                completedLogMsg += ' (' + name + ')';
+                if (typeof name === 'object' && name.path) {
+                    taskName = name.path;
+                }
+                else if (typeof name === 'string') {
+                    taskName = name;
+                }
+                logMsg += ' (' + taskName + ')';
+                completedLogMsg += ' (' + taskName + ')';
             }
 
             if (timeoutMillis && timeoutMillis > 0) {
@@ -105,18 +116,18 @@ module.exports = function warmup(app, tasks, options, callback) {
                         callback(new Error('Warmup task timed out after ' + timeoutMillis + 'ms: ' + (name || '(anonymous)')));
                     }, timeoutMillis);
 
-                    func.call(context, function() {
+                    func.call(context, function(err) {
                         log(completedLogMsg);
                         clearTimeout(timeoutId);
-                        callback();
+                        callback(err);
                     });
                 };
             } else {
                 return function(callback) {
                     log(logMsg);
-                    return func.call(context, function() {
+                    return func.call(context, function(err) {
                         log(completedLogMsg);
-                        callback();
+                        callback(err);
                     });
                 };
             }
@@ -124,7 +135,6 @@ module.exports = function warmup(app, tasks, options, callback) {
 
         var asyncTasks = tasks.map(function(task, i) {
             if (typeof task === 'string' || typeof task === 'object') {
-                console.log('\nTask: ', task);
                 return wrapTask(createWarmupUrlTask(task), i, task);
             }
             else {

--- a/lib/warmup.js
+++ b/lib/warmup.js
@@ -32,7 +32,7 @@ module.exports = function warmup(app, tasks, options, callback) {
     var listenAttemptCount = 0;
 
     function createWarmupUrlTask(data) {
-        var host = 'http://localost:' + warmupPort;
+        var host = 'http://localhost:' + warmupPort;
         var reqObj;
         var path;
         var url;


### PR DESCRIPTION
- Creating request object from path (if string)
- Accepting headers in the request object
- Sample request object passed from user: 

```
{
            path: '/sch/i.html?_nkw=handbag&warmup=true',
            headers: {
                'User-Agent':'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4',
                'Accept':'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp',
                'Accept-Encoding': 'gzip, deflate, sdch'
            }
        }
```
- Passing err to user
